### PR TITLE
Cleanup for rails_start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ After the machine has been created/provisioned successfully, you can log in with
     
 Within the virtual machine, the __ubuntu__ user owns the code and installed directory.
 
-On first login, a script will finish installing and initializing Rails and the Dryad system. To run the rails server, use the alias `rails_start`.
+On first login, a script will finish installing and initializing Rails and the Dryad system. To run the rails server, use the script `rails_start.sh`.
 
 To shut down the virtual machine, use
 

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -30,7 +30,7 @@
   become: no
 
 - name: Copy rails_start script into bin directory
-  template: src=rails_start.sh.j2 dest="{{ user_home }}/bin/rails_start.sh"
+  template: src=rails_start.sh.j2 dest="{{ user_home }}/bin/rails_start.sh" mode=0755
   become: no
 
 - name: Finish ruby and rails install on first login

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -30,7 +30,7 @@
   become: no
 
 - name: Copy rails_start script into bin directory
-  template: src=rails_start.sh.j2 dest="{{ user_home }}/bin/rails_start.sh" mode=0755
+  template: src=rails_start.sh.j2 dest="{{ user_home }}/bin/rails_start.sh" mode="u+rwx" 
   become: no
 
 - name: Finish ruby and rails install on first login

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -25,6 +25,10 @@
   template: src=bash_profile.j2 dest="{{ user_home }}/.bash_profile" mode=0644
   become: no
 
+- name: ensure bin directory exists
+  file: path="{{ user_home }}/bin" state=directory mode="u+rwx" 
+  become: no
+
 - name: Copy rails_start script into bin directory
   template: src=rails_start.sh.j2 dest="{{ user_home }}/bin/rails_start.sh"
   become: no


### PR DESCRIPTION
On a fresh machine, the bin directory needs to be created before placing files into it, and the rails_start.sh needs to be executable.