### PR TITLE
Add DB config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ If you wish to destroy the virtual machine
 
     vagrant destroy
 
+## Final configuration
+
+Although you can start rails as soon as the VM is running, some final configuration is required before everything will work correctly:
+- Edit the files in the directory `dryad-config/config` to contain the appropriate credentials and settings.
+- If you are using the ORCID login, you will need to have ORCID add the DNS name of the VM to their list of approved redirects.
+- If you want to use http (the default config is not set up for https), the DNS name of the machine must be listed in the omniauth exclusions. Machines named <something>dash.datadryad.org are already allowed. See `stash_engine/config/initializers/omniauth.rb`.
+
 ## Customizing the Vagrant-built VM
 
 Beyond the above required changes, you can further customize the development environment. If you wish to customize further, it's a good idea to familiarize yourself with Vagrant's [command-line interface](http://docs.vagrantup.com/v2/cli/).

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -20,7 +20,11 @@
 - name: Symlink config files
   shell: cd dryad; mkdir -p config/tenants; ./symlink_config.sh
   become: no
-  
+
+- name: Copy vagrant database config into place
+  template: src=database.yml.j2 dest="{{ user_home }}/dryad-config/config/database.yml" mode=0644
+  become: no
+
 - name: Install bash profile for path and database variables
   template: src=bash_profile.j2 dest="{{ user_home }}/.bash_profile" mode=0644
   become: no

--- a/ansible/roles/common/templates/database.yml.j2
+++ b/ansible/roles/common/templates/database.yml.j2
@@ -1,8 +1,8 @@
 default: &default
   adapter: mysql2
-  username: {{ db.user }}
-  database: {{ db.name }}
-  password: {{ db.password }}
+  username: {{ dryad.db.user }}
+  database: {{ dryad.db.name }}
+  password: {{ dryad.db.password }}
   port: 3306
   encoding: utf8mb4
   collation: utf8mb4_unicode_ci

--- a/ansible/roles/common/templates/database.yml.j2
+++ b/ansible/roles/common/templates/database.yml.j2
@@ -1,0 +1,16 @@
+default: &default
+  adapter: mysql2
+  username: {{ db.user }}
+  database: {{ db.name }}
+  password: {{ db.password }}
+  port: 3306
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
+ 
+development:
+  <<: *default
+  host: 127.0.0.1 # change these lines or override lines from default if they are not right
+
+test:
+  <<: *default
+  database: dashv2_test


### PR DESCRIPTION
During provisioning, builds a new database.yml file using the same info that was used to create the database. Without this, the database cannot be migrated properly on initial login, which creates errors and a somewhat confusing launch experience.

After adding this, you should be able to start a new server from scratch and after letting the initial installation scripts run on login, you can immediately run rails_start.sh (Note that the ORCID config must still be updated in app_config.yml before users can actually login to Dryad.)