### PR TITLE
Changes for egrep so it would be compatible with Mac differences in utilities, also.

### DIFF
--- a/ansible/roles/common/templates/sshuttle.sh.j2
+++ b/ansible/roles/common/templates/sshuttle.sh.j2
@@ -10,7 +10,7 @@ ssh_server="{{ dryad.tunnel.sshConnection }}"
 declare -a out_array
 for i in "${domain_arr[@]}"
 do
-    my_output="$(dig +short $i | grep -P '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')"
+    my_output="$(dig +short $i | egrep '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$')"
     while read -r line; do
         out_array+=("$line")
     done <<< "$my_output"
@@ -23,7 +23,7 @@ case "$1" in
             echo "sshuttle is already started"
         else
             echo "Starting sshuttle and tunneling these IPs: ${out_array[*]}"
-            sshuttle -r $ssh_server "${out_array[@]}" -D --pidfile $FILE
+            sshuttle -r $ssh_server ${out_array[@]} -D --pidfile $FILE
         fi
         ;;
     stop)


### PR DESCRIPTION
Otherwise the default installed grep acts different.  Also changed /d to [0-9] since it's compatible on both and don't need perl-style regular expressions.

I tested this both on AWS and on my Mac (with appropriate stuff filled in for domains and tunnel server) and it worked both places.